### PR TITLE
Removed normal Norwegian words.

### DIFF
--- a/no
+++ b/no
@@ -1,6 +1,4 @@
 drittsekk
-ene
-er
 faen i helvete
 fitte
 jævla


### PR DESCRIPTION
The words for "(the) one" ((den) ene) and "am" (er) did not seem appropriate for a list such as this. If they are meant for filtering out words without meaning though, there are quite a lot of words missing.
