### PR TITLE
Remove `bi curious` from list of badwords

### DIFF
--- a/en
+++ b/en
@@ -32,7 +32,6 @@ bdsm
 beaver cleaver
 beaver lips
 bestiality
-bi curious
 big black
 big breasts
 big knockers


### PR DESCRIPTION
By all account `bi curious` is in no way a bad word and remains the most respectful way to refer to many peoples sexual preferences. 