### PR TITLE
Add 'fuckin' to en

### DIFF
--- a/en
+++ b/en
@@ -143,6 +143,7 @@ footjob
 frotting
 fuck
 fuck buttons
+fuckin
 fucking
 fudge packer
 fudgepacker


### PR DESCRIPTION
This changeset adds a slang variation for the word *fuck*. If I'm not mistaking, it should actually be spelled *fuckin'*, but hey, you gotta consider what we're dealing with :)