### PR TITLE
Removed inoffensive LGBTQ/heterosexual words

### DIFF
--- a/pt
+++ b/pt
@@ -7,7 +7,6 @@ balalao
 bastardo
 bicha
 biscate
-bissexual
 boceta
 boob
 bosta
@@ -43,12 +42,8 @@ frango assado
 gozar
 grelho
 heroína
-heterosexual
-homem gay
 homoerótico
-homosexual
 inferno
-lésbica
 lolita
 mama
 merda


### PR DESCRIPTION
Removed Portuguese equivalents of bisexual, gay man, heterosexual, homosexual and lesbian because these are not bad words.