### PR TITLE
Remove non-offensive words from the German list

### DIFF
--- a/de
+++ b/de
@@ -6,7 +6,6 @@ arschloch
 bimbo
 bratze
 bumsen
-bonze
 dödel
 fick
 ficken
@@ -41,10 +40,7 @@ orgasmus
 penis
 pimmel
 pimpern
-pinkeln
-pissen
 pisser
-popel
 poppen
 porno
 reudig
@@ -53,7 +49,6 @@ schabracke
 schlampe
 scheiße
 scheisser
-schiesser
 schnackeln
 schwanzlutscher
 schwuchtel


### PR DESCRIPTION
These following five words should be removed from the list:

* "pissen" which means "to pee"
* "pinkeln" which means "to pee"
* "popel" which means "snot" or "pople"
* "schiesser" is not commonly used in the german language and means "shooter"
* "bonze" which means "rich kid"