### PR TITLE
Update fr removing anatomic word

### DIFF
--- a/fr
+++ b/fr
@@ -20,7 +20,6 @@ chiasse
 chier
 chiottes
 clito
-clitoris
 con
 connard
 connasse


### PR DESCRIPTION
The word `clitoris` is the name of a female sex organ which not dirty nor obscene at all. At least not more than the male homologue equivalent `pénis` (penis) which is not in the list. Both male and female words can obviously be present in obscene texts but if one is present in the list, both should be.