### PR TITLE
remove non-swears and duplicates from PL

### DIFF
--- a/pl
+++ b/pl
@@ -1,25 +1,18 @@
 burdel
-burdelmama
 chuj
 chujnia
 ciota
 cipa
 cyc
 debil
-dmuchać
-do kurwy nędzy
 dupa
 dupek
 duperele
 dziwka
 fiut
 gówno
-gówno prawda
 huj
-huj ci w dupę
 jajco
-jajko
-ja pierdolę
 jebać
 jebany
 kurwa
@@ -27,21 +20,18 @@ kurwy
 kutafon
 kutas
 lizać pałę
-obciągać chuja
-obciągać fiuta
-obciągać loda
+obciągać
 pieprzyć
 pierdolec
+pierdolę
 pierdolić
 pierdolnąć
 pierdolnięty
-pierdoła
 pierdzieć
 pizda
 pojeb
 pojebany
 popierdolony
-robic loda
 robić loda
 ruchać
 rzygać
@@ -49,6 +39,5 @@ skurwysyn
 sraczka
 srać
 suka
-syf
 wkurwiać
 zajebisty


### PR DESCRIPTION
some words were redundant, e.g. "do kurwy nędzy" is already covered by "kurwy". some were not swears, e.g. "dmuchać" = "to blow" (as in blow a candle, not really used with sexual connotations in contemporary polish), "jajko" = "egg" (can indeed be used to mean balls, but should we also ban "banana" cause someone might use it for penis?), "syf" just means "a mess" and is not a swear word.